### PR TITLE
[Feat] Admin 회원가입 용 테스트 코드 생성 - 추후 삭제 #19

### DIFF
--- a/src/main/java/com/sparta/icticket/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/icticket/config/SecurityConfig.java
@@ -71,6 +71,7 @@ public class SecurityConfig {
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers(HttpMethod.POST, "/users").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/users/admin").permitAll() //테스트용 입니다. 추후에 삭제해야 합니다.
                         .requestMatchers("/users/login").permitAll()
                         .requestMatchers("/admin/**").hasRole(UserRole.ADMIN.toString())
                         .anyRequest().authenticated()

--- a/src/main/java/com/sparta/icticket/user/User.java
+++ b/src/main/java/com/sparta/icticket/user/User.java
@@ -59,6 +59,18 @@ public class User extends Timestamped {
         this.userRole = UserRole.USER;
     }
 
+    //[테스트용 어드민]
+    public User(UserSignupRequestDto userSignupRequestDto, String encodedPassword, UserRole userRole) {
+        this.email = userSignupRequestDto.getEmail();
+        this.password = encodedPassword;
+        this.name = userSignupRequestDto.getName();
+        this.nickname = userSignupRequestDto.getNickname();
+        this.phoneNumber = userSignupRequestDto.getPhoneNumber();
+        this.address = userSignupRequestDto.getAddress();
+        this.userStatus = UserStatus.ACTIVATE;
+        this.userRole = userRole;
+    }
+
     public void saveRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }

--- a/src/main/java/com/sparta/icticket/user/UserController.java
+++ b/src/main/java/com/sparta/icticket/user/UserController.java
@@ -42,6 +42,19 @@ public class UserController {
         return ResponseEntity.ok(new ResponseMessageDto(SuccessStatus.USER_SIGN_UP_SUCCESS));
     }
 
+
+    /**
+     * [테스트용]어드민 회원 가입 기능
+     * @param requestDto
+     * @return
+     */
+    @PostMapping("/admin")
+    public ResponseEntity<ResponseMessageDto> createAdminUser(
+            @Valid @RequestBody UserSignupRequestDto requestDto) {
+        userService.createAdminUser(requestDto);
+        return ResponseEntity.ok(new ResponseMessageDto(SuccessStatus.USER_SIGN_UP_SUCCESS));
+    }
+
     /**
      * 로그아웃 기능
      *

--- a/src/main/java/com/sparta/icticket/user/UserService.java
+++ b/src/main/java/com/sparta/icticket/user/UserService.java
@@ -1,6 +1,7 @@
 package com.sparta.icticket.user;
 
 import com.sparta.icticket.common.enums.ErrorType;
+import com.sparta.icticket.common.enums.UserRole;
 import com.sparta.icticket.common.enums.UserStatus;
 import com.sparta.icticket.common.exception.CustomException;
 import com.sparta.icticket.order.OrderRepository;
@@ -34,6 +35,21 @@ public class UserService {
         String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
 
         User saveUser = new User(requestDto, encodedPassword);
+
+        userRepository.save(saveUser);
+    }
+
+    /**
+     * [테스트용]어드민 회원 가입
+     * @param requestDto
+     */
+    public void createAdminUser(UserSignupRequestDto requestDto) {
+        checkDuplicateEmail(requestDto.getEmail());
+        checkDuplicateNickname(requestDto.getNickname());
+
+        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+        User saveUser = new User(requestDto, encodedPassword, UserRole.ADMIN);
 
         userRepository.save(saveUser);
     }


### PR DESCRIPTION
## 📌 연관된 이슈
> Issue Number : #19

## 💻 작업 내용
어드민 로그인용 테스트 코드 추가했습니다.
호출 방법은 http://localhost:8080/users/admin
입니다.

